### PR TITLE
feat: add exports for better esm support

### DIFF
--- a/libs/evm/package.json
+++ b/libs/evm/package.json
@@ -2,13 +2,9 @@
   "name": "@xpla/evm",
   "version": "1.8.0",
   "description": "TypeChain generated TypeScript interfaces for XPLA EVM smart contracts",
-  "main": "dist/index.js",
-  "module": "dist/esm/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "dist",
-    "README.md"
-  ],
+  "main": "index.js",
+  "module": "esm/index.js",
+  "types": "index.d.ts",
   "exports": {
     ".": {
       "import": "./esm/index.js",
@@ -63,6 +59,7 @@
     "typescript": "^5.0.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "directory": "dist"
   }
 }

--- a/libs/evm/package.json
+++ b/libs/evm/package.json
@@ -9,6 +9,24 @@
     "dist",
     "README.md"
   ],
+  "exports": {
+    ".": {
+      "import": "./esm/index.js",
+      "require": "./index.js",
+      "types": "./index.d.ts"
+    },
+    "./*": {
+      "import": "./esm/*.js",
+      "require": "./*.js",
+      "types": "./*.d.ts"
+    },
+    "./*.js": {
+      "import": "./esm/*.js",
+      "require": "./*.js",
+      "types": "./*.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "build": "npm run clean && tsc && tsc -p tsconfig.esm.json",
     "clean": "rimraf dist",
@@ -48,4 +66,3 @@
     "access": "public"
   }
 }
-  

--- a/libs/xpla-react/package.json
+++ b/libs/xpla-react/package.json
@@ -16,6 +16,24 @@
     "access": "public",
     "directory": "dist"
   },
+  "exports": {
+    ".": {
+      "import": "./esm/index.js",
+      "require": "./index.js",
+      "types": "./index.d.ts"
+    },
+    "./*": {
+      "import": "./esm/*.js",
+      "require": "./*.js",
+      "types": "./*.d.ts"
+    },
+    "./*.js": {
+      "import": "./esm/*.js",
+      "require": "./*.js",
+      "types": "./*.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "copy": "copyfiles -f README.md package.json dist",
     "clean": "rimraf dist/**",

--- a/libs/xplajs/package.json
+++ b/libs/xplajs/package.json
@@ -14,6 +14,24 @@
     "access": "public",
     "directory": "dist"
   },
+  "exports": {
+    ".": {
+      "import": "./esm/index.js",
+      "require": "./index.js",
+      "types": "./index.d.ts"
+    },
+    "./*": {
+      "import": "./esm/*.js",
+      "require": "./*.js",
+      "types": "./*.d.ts"
+    },
+    "./*.js": {
+      "import": "./esm/*.js",
+      "require": "./*.js",
+      "types": "./*.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@cosmjs/stargate": "^0.33.0",
     "@cosmology/lcd": "^0.14.4",

--- a/networks/xpla/package.json
+++ b/networks/xpla/package.json
@@ -15,6 +15,24 @@
     "access": "public",
     "directory": "dist"
   },
+  "exports": {
+    ".": {
+      "import": "./esm/index.js",
+      "require": "./index.js",
+      "types": "./index.d.ts"
+    },
+    "./*": {
+      "import": "./esm/*.js",
+      "require": "./*.js",
+      "types": "./*.d.ts"
+    },
+    "./*.js": {
+      "import": "./esm/*.js",
+      "require": "./*.js",
+      "types": "./*.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "copy": "copyfiles -f README.md package.json dist",
     "clean": "rimraf dist/**",


### PR DESCRIPTION
currently, it's not tree-shaking friendly.

```ts
import { baz } from '@xpla/xplajs/foo/bar/baz'
```

this will be resolved as commonjs even with `import` since `"module": "dist/esm/index.js"` is only entry for esm.
consumer projects should `/esm/` explicitly for tree-shaking now.

```ts
import { baz } from '@xpla/xplajs/esm/foo/bar/baz'
```

so this PR adds proper `exports` configuration for better tree-shaking support.