### PR TITLE
fix: restore sequencer for OOM

### DIFF
--- a/e2e/testSequencer.ts
+++ b/e2e/testSequencer.ts
@@ -1,0 +1,26 @@
+import type { TestSpecification } from 'vitest/node';
+
+export class TestSequencer {
+  async sort(files: TestSpecification[]) {
+    const testOrder = ['token.test.ts', 'evm.test.ts'];
+
+    return files.sort((a, b) => {
+      const aName = a.moduleId.split('/').pop() || '';
+      const bName = b.moduleId.split('/').pop() || '';
+
+      const aIndex = testOrder.indexOf(aName);
+      const bIndex = testOrder.indexOf(bName);
+
+      if (aIndex !== -1 && bIndex !== -1) {
+        return aIndex - bIndex;
+      }
+      if (aIndex !== -1) return -1;
+      if (bIndex !== -1) return 1;
+
+      return aName.localeCompare(bName);
+    });
+  }
+  async shard(files: TestSpecification[]) {
+    return files;
+  }
+}

--- a/e2e/vitest.config.ts
+++ b/e2e/vitest.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitest/config';
+import { TestSequencer } from './testSequencer';
 
 export default defineConfig({
   test: {
@@ -17,6 +18,9 @@ export default defineConfig({
           testTimeout: 200_000,
           hookTimeout: 200_000,
           fileParallelism: false,
+          sequence: {
+            sequencer: TestSequencer,
+          },
         },
       },
     ],


### PR DESCRIPTION
test sequencer was missed from #20 mistakenly, [leading OOM on CI](https://github.com/xpladev/xplajs/actions/runs/22839183636/job/66241793517).