### PR TITLE
fix: add missing typecheck after tsdown migration

### DIFF
--- a/.github/actions/setup-build/action.yaml
+++ b/.github/actions/setup-build/action.yaml
@@ -19,6 +19,10 @@ runs:
       shell: bash
       run: pnpm install
 
+    - name: Type Check
+      shell: bash
+      run: pnpm typecheck
+
     - name: Build Packages
       shell: bash
       run: pnpm build

--- a/libs/xpla-react/package.json
+++ b/libs/xpla-react/package.json
@@ -39,6 +39,7 @@
   },
   "scripts": {
     "build": "tsdown",
+    "typecheck": "tsc --noEmit",
     "lint": "eslint . --fix"
   },
   "dependencies": {

--- a/libs/xplajs/package.json
+++ b/libs/xplajs/package.json
@@ -7,7 +7,8 @@
   "author": "Joowon Yun <joowon@delightlabs.io>",
   "homepage": "https://github.com/xpladev/xplajs",
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "typecheck": "tsc --noEmit"
   },
   "publishConfig": {
     "access": "public"

--- a/networks/xpla/package.json
+++ b/networks/xpla/package.json
@@ -38,6 +38,7 @@
   },
   "scripts": {
     "build": "tsdown",
+    "typecheck": "tsc --noEmit",
     "lint": "eslint . --fix"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "proto": "telescope download --config ./scripts/xpla.protod.config.json",
     "codegen": "tsx ./scripts/codegen.cts && pnpm run codegen:fix",
     "codegen:fix": "eslint --config eslint.codegen.config.js --fix libs/*/src networks/*/src",
+    "typecheck": "pnpm -r run typecheck",
     "build": "lerna run build --stream",
     "test:module": "pnpm --filter @xpla/e2e run test:module",
     "test:starship": "pnpm --filter @xpla/e2e run test:starship",


### PR DESCRIPTION
## Background

While migrating to tsdown from tsc, we should have kept tsc with `noEmit` for typecheck.

Missing typecheck concealed a bug from updates of @cosmjs/stargate, @cosmjs/tendermint-rpc.
They have breakings and telescope codegen depends on deprecated APIs.

## Description

Adds typecheck scripts to each package and workflow.
~~Downgrades @cosmjs/* dependencies and pins to working versions~~